### PR TITLE
Added dropdown node

### DIFF
--- a/mining/grafana-debug.json
+++ b/mining/grafana-debug.json
@@ -1,12 +1,19 @@
 {
   "__inputs": [
     {
-      "name": "DS_GRAFANACLOUD-ARWEAVE-PROM",
-      "label": "grafanacloud-arweave-prom",
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_JOBNAME",
+      "type": "constant",
+      "label": "job_name",
+      "value": "arweave",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -15,7 +22,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.1.0-69950"
+      "version": "12.0.2"
     },
     {
       "type": "datasource",
@@ -65,7 +72,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The read rate for each partition as measured by the time it takes to read each 100MiB recall range. This value should not be impacted by any other bottlenecks in the mining pipeline and should pretty closely represent the observed read rate per partition.",
           "fieldConfig": {
@@ -146,7 +153,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "disableTextWrap": false,
               "editorMode": "code",
@@ -163,7 +170,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "disableTextWrap": false,
               "editorMode": "code",
@@ -184,7 +191,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This panel shows how much of your configured chunk cache is being used (measured in 256 KiB chunks). You can change the chunk cache size limit using the `mining_server_chunk_cache_size_limit` launch parameter. The current limit is printed during node launch. \n\nIncreasing the chunk cache size limit can increase the memory used by your node while mining, but can also improve hashrate. The cache allows the miner to \"catch up\" if it falls behind temporarily due to other processes competing for resources. If your miner is consistently unable to keep up with new VDF steps, increasing the cache is unlikely to help (and my in fact hurt if it causes your node to exhaust available memory and go into swap).\n\nNote: you may see your actual chunk cache size exceed the limit occasionally. This is expected due to how the increments are recorded (increments of 800 per partition).",
           "fieldConfig": {
@@ -264,7 +271,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -280,7 +287,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -315,7 +322,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "HTTP requests your node receives per second.",
           "fieldConfig": {
@@ -397,7 +404,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum by(http_method, route) (rate(cowboy_requests_total{instance=\"$node\"}[5m]))",
@@ -412,7 +419,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Total number of HTTP requests your node makes to peers",
           "fieldConfig": {
@@ -495,7 +502,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "expr": "sum by(route, http_method) (rate(ar_http_request_duration_seconds_count{instance=\"$node\"}[5m]))",
@@ -510,7 +517,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Total latency of the HTTP requests your node receives",
           "fieldConfig": {
@@ -595,7 +602,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum by(http_method, route) (rate(cowboy_request_duration_seconds_sum{instance=\"$node\"}[5m]))",
@@ -610,7 +617,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Total latency of the HTTP requests your node makes to peers",
           "fieldConfig": {
@@ -693,7 +700,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum by(route, http_method) (rate(ar_http_request_duration_seconds_sum{instance=\"$node\"}[5m]))",
@@ -708,7 +715,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Average latency of the HTTP requests your node receives",
           "fieldConfig": {
@@ -793,7 +800,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "(sum by(http_method, route) (rate(cowboy_request_duration_seconds_sum{instance=\"$node\"}[5m]))) /\n(sum by(http_method, route) (rate(cowboy_request_duration_seconds_count{instance=\"$node\"}[5m])))",
@@ -808,7 +815,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Average latency of the HTTP requests your node makes to peers",
           "fieldConfig": {
@@ -891,7 +898,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum by(route, http_method) (rate(ar_http_request_duration_seconds_sum{instance=\"$node\"}[5m])) / sum by(route, http_method) (rate(ar_http_request_duration_seconds_count{instance=\"$node\"}[5m]))",
@@ -923,7 +930,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "CPU load is measured per *virtual* core. If you have a 16-core CPU with Hyperthreading/SMT enabled, you will likely have 32 virtual cores. Set the dashboard variable appropriately to get a sense of your overall CPU load.",
       "fieldConfig": {
@@ -940,6 +947,7 @@
             "axisSoftMax": 100,
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -970,8 +978,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "#EAB839",
@@ -1030,17 +1037,18 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "9.5.0-cloud.5.a016665c",
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "(sum(rate(process_cpu_seconds_total{instance=~\"$node\"}[5m])) without (kind) * 100) / $cores",
@@ -1056,7 +1064,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Tracks the memory used by each erlang process.",
       "fieldConfig": {
@@ -1071,6 +1079,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "bars",
             "fillOpacity": 100,
             "gradientMode": "none",
@@ -1101,8 +1110,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1692,16 +1700,18 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1716,7 +1726,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "process_virtual_memory_bytes{instance=~\"$node\"}",
@@ -1729,7 +1739,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "process_resident_memory_bytes{instance=~\"$node\"}",
@@ -1742,7 +1752,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "process_max_resident_memory_bytes{instance=~\"$node\"}",
@@ -1755,7 +1765,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1775,7 +1785,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of messages stored in each erlang process's message queue. Erlang processes can be though of as threads without shared memory. They send messages to communicate with each other. Before being processed a message is stored in a message queue. If a process's message queue is growing it means that process is receiving more messages than it can process and can help pinpoint the root cause of performance issues.",
       "fieldConfig": {
@@ -1790,6 +1800,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1820,8 +1831,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1851,16 +1861,18 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "sum by(process) (process_info{instance=\"$node\", type=\"message_queue\"})",
@@ -1875,7 +1887,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Reductions are a measure of erlang process activity. The more reductions performed by a process, the more CPU cycles it has consumed.",
       "fieldConfig": {
@@ -1890,6 +1902,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1920,8 +1933,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1951,16 +1963,18 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1978,37 +1992,35 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "YOUR-PROMETHEUS-INSTANCE",
-          "value": "YOUR-PROMETHEUS-INSTANCE"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
-        "hide": 0,
+        "definition": "label_values({job=\"$JOBNAME\"}, instance)",
+        "includeAll": false,
+        "label": "Node",
         "name": "node",
-        "options": [
-          {
-            "selected": true,
-            "text": "YOUR-PROMETHEUS-INSTANCE",
-            "value": "YOUR-PROMETHEUS-INSTANCE"
-          }
-        ],
-        "query": "YOUR-PROMETHEUS-INSTANCE",
-        "skipUrlSync": false,
-        "type": "textbox"
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"$JOBNAME\"}, instance)",
+          "refId": "Prometheus-nodename-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "1",
           "value": "1"
         },
-        "hide": 0,
-        "label": "",
         "name": "cores",
         "options": [
           {
@@ -2018,8 +2030,28 @@
           }
         ],
         "query": "1",
-        "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "description": "Enter the job_name as specified in prometheus.yml",
+        "hide": 2,
+        "label": "job_name",
+        "name": "JOBNAME",
+        "query": "${VAR_JOBNAME}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOBNAME}",
+          "text": "${VAR_JOBNAME}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_JOBNAME}",
+            "text": "${VAR_JOBNAME}",
+            "selected": false
+          }
+        ]
       }
     ]
   },
@@ -2027,11 +2059,10 @@
     "from": "now-30m",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "browser",
-  "title": "Sample Debugging  Dashboard",
-  "uid": "debugging",
-  "version": 25,
+  "title": "Arweave Debugging",
+  "uid": "arweave-debugging",
+  "version": 26,
   "weekStart": ""
 }

--- a/mining/grafana-mining.json
+++ b/mining/grafana-mining.json
@@ -1,12 +1,19 @@
 {
   "__inputs": [
     {
-      "name": "DS_GRAFANACLOUD-ARWEAVE-PROM",
-      "label": "grafanacloud-arweave-prom",
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_JOBNAME",
+      "type": "constant",
+      "label": "job_name",
+      "value": "arweave",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -15,7 +22,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.1.0-68838"
+      "version": "12.0.2"
     },
     {
       "type": "datasource",
@@ -55,7 +62,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric tracks the number of chunks read per second. 1 chunk is 256kib.\n\nThe protocol allows for up to 800 chunks per partition per VDF step to be read. That equates to roughly 200MiB/s per partition.\n\nWe recommend setting an alert at 0 MiB/s as that indicates the miner is no longer mining. You may also want to set an alert at some drop below an established baseline.",
       "fieldConfig": {
@@ -70,6 +77,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -100,8 +108,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -131,16 +138,18 @@
           ""
         ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -157,7 +166,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -174,7 +183,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -195,7 +204,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric tracks the miner hashrate. The protocol allows for up to 400 H1 hashes and 400 H2 hashes per partition per VDF step. The metric also consider that an H1 hash is 100x less likely to result in a solution and scales the H1 hash count down accordingly. You can roughly interpret that as the protocol allowing 404 solution attempts (combination of H1 and H2 hashes) per partition per VDF step.\n\nNote: hashes are generated after chunks are read, so if your Read Rate chart shows a low read rate, your Hash Rate chart will also be lower.\n\nRe recommend setting an alert on 0 as that indicates your miner is no longer mining. You may also want to establish a baseline and set an alert if hashrate falls some amount below that baseline",
       "fieldConfig": {
@@ -210,6 +219,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -240,8 +250,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -271,16 +280,18 @@
           ""
         ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -297,7 +308,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -314,7 +325,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -331,7 +342,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -352,7 +363,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric combines two values:\n1. Your miner's actual read rate\n2. The ideal read rate for an optimal miner with the same set of data sync and the same VDF speed.\n\nThe result is a percentage where 100% indicates you are mining at the ideal rate. The rate can exceed 100% for two reasons:\n1. The ideal and actual metrics are calculated on slightly different periods and so there might be some oscillation in the percentage.\n2. If your miner is mining as part of a coordinated mining set, the ideal rate is currently calculated assuming your miner is solo mining and doesn't take into account the hashes that your miner will perform for coordinated mining peers. ",
       "fieldConfig": {
@@ -367,6 +378,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -397,8 +409,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -428,16 +439,18 @@
           ""
         ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -454,7 +467,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -471,7 +484,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -492,7 +505,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric combines two values:\n1. Your miner's actual hash rate\n2. The ideal hash rate for an optimal miner with the same set of data sync and the same VDF speed.\n\nThe result is a percentage where 100% indicates you are mining at the ideal rate. The rate can exceed 100% for two reasons:\n1. The ideal and actual metrics are calculated on slightly different periods and so there might be some oscillation in the percentage.\n2. If your miner is mining as part of a coordinated mining set, the ideal rate is currently calculated assuming your miner is solo mining and doesn't take into account the hashes that your miner will perform for coordinated mining peers. ",
       "fieldConfig": {
@@ -507,6 +520,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -537,8 +551,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -568,16 +581,18 @@
           ""
         ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -594,7 +609,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -611,7 +626,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -628,7 +643,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -649,7 +664,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric tracks the current VDF step number of the node - either calculated locally or received from a trusted VDF server. \n\nYou expect this number to increase roughly every second. We recommend starting with an alert that goes off if there are fewer than 200 steps in a 5-minute period.",
       "fieldConfig": {
@@ -664,6 +679,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -694,8 +710,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -704,32 +719,7 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "YOUR-NODE-INSTANCE-LABEL"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -746,16 +736,18 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -775,7 +767,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric tracks the height of the node's current tip node. We expect this number to increase roughly ever 2 minutes, but there can be substantial variation in the block time. We recommend alerting if you don't see a new block in 15 minutes.",
       "fieldConfig": {
@@ -790,6 +782,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -820,8 +813,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -830,32 +822,7 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "YOUR-NODE-INSTANCE-LABEL"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -872,16 +839,18 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -901,7 +870,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "This metric tracks how many VDF steps the node is behind the last block it processed. A negative number means the node is *ahead* of the VDF step in the block.\n\nIf this number grows too large it can indicate that the node's VDF or VDF server is too slow or has fallen behind. We recommend setting an alert at 200, and adjusting as needed.",
       "fieldConfig": {
@@ -946,8 +915,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -982,7 +950,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ARWEAVE-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "block_vdf_advance{instance=~\"$node\"}",
@@ -996,28 +964,51 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 39,
+  "refresh": "",
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "YOUR-NODE-INSTANCE-LABEL",
-          "value": "YOUR-NODE-INSTANCE-LABEL"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
-        "hide": 0,
+        "definition": "label_values({job=\"$JOBNAME\"}, instance)",
+        "includeAll": false,
+        "label": "Node",
         "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"$JOBNAME\"}, instance)",
+          "refId": "Prometheus-nodename-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "description": "Enter the job_name as specified in prometheus.yml",
+        "hide": 2,
+        "label": "job_name",
+        "name": "JOBNAME",
+        "query": "${VAR_JOBNAME}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOBNAME}",
+          "text": "${VAR_JOBNAME}",
+          "selected": false
+        },
         "options": [
           {
-            "selected": true,
-            "text": "YOUR-NODE-INSTANCE-LABEL",
-            "value": "YOUR-NODE-INSTANCE-LABEL"
+            "value": "${VAR_JOBNAME}",
+            "text": "${VAR_JOBNAME}",
+            "selected": false
           }
-        ],
-        "query": "YOUR-NODE-INSTANCE-LABEL",
-        "skipUrlSync": false,
-        "type": "textbox"
+        ]
       }
     ]
   },
@@ -1025,11 +1016,10 @@
     "from": "now-30m",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "browser",
-  "title": "Arweave Miner",
-  "uid": "cdi53ryl7bvnkf",
-  "version": 18,
+  "title": "Arweave Mining",
+  "uid": "arweave-mining",
+  "version": 19,
   "weekStart": ""
 }

--- a/mining/grafana-mining.json
+++ b/mining/grafana-mining.json
@@ -854,7 +854,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "arweave_block_height{instance=\"$node\"}",
+          "expr": "arweave_block_height{instance=\"$node\"} > 0",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/mining/grafana-syncing-packing.json
+++ b/mining/grafana-syncing-packing.json
@@ -1,4 +1,48 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_JOBNAME",
+      "type": "constant",
+      "label": "job_name",
+      "value": "arweave",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -18,13 +62,77 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 130,
+  "id": null,
   "links": [],
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "delta"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(chunks_stored{instance=\"$node\"}) * 256 * 1000",
+          "legendFormat": "Chunks Written",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Chunks Written (in bytes)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -69,8 +177,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -86,7 +193,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 7,
       "options": {
@@ -104,9 +211,13 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0-81311",
+      "pluginVersion": "12.0.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "sum(v2_index_data_size_by_packing{instance=\"$node\"}) by (partition_number, packing)",
           "legendFormat": "{{partition_number}} {{packing}}",
@@ -120,7 +231,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -165,8 +276,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -182,7 +292,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 3
       },
       "id": 6,
       "options": {
@@ -202,9 +312,13 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0-81311",
+      "pluginVersion": "12.0.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "rate(replica_2_9_entropy_stored{instance=\"$node\"}[2m])",
           "hide": false,
@@ -215,7 +329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(replica_2_9_entropy_stored{instance=\"$node\"}[2m]))",
@@ -231,7 +345,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "GET /chunk2 requests sent per second to different peers. Each successful request downloads a chunk to your node.",
       "fieldConfig": {
@@ -277,8 +391,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -357,7 +470,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 13
       },
       "id": 1,
       "options": {
@@ -376,12 +489,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0-81311",
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by(peer) (rate(http_client_get_chunk_duration_seconds_count{instance=\"$node\"}[2m]))",
@@ -392,7 +505,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_client_get_chunk_duration_seconds_count{instance=\"$node\"}[2m]))",
@@ -408,7 +521,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Each chunk written is assumed to be 256 KiB.\n\nNote: this may differ from your packing rate as each chunk written may need a different number of packing operations (0 to 2 depending on the format the chunk is received and the format it is written)",
       "fieldConfig": {
@@ -454,8 +567,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -471,7 +583,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 13
       },
       "id": 3,
       "options": {
@@ -490,12 +602,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0-81311",
+      "pluginVersion": "12.0.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(chunks_stored{instance=\"$node\"}[2m]) * 256 * 1024",
@@ -507,7 +619,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(chunks_stored{instance=\"$node\"}[1h]) * 256 * 1024",
@@ -523,7 +635,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Average latency for sync requests made to each peer",
       "fieldConfig": {
@@ -569,8 +681,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -621,7 +732,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 23
       },
       "id": 2,
       "options": {
@@ -645,7 +756,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by(peer) (rate(http_client_get_chunk_duration_seconds_sum{instance=\"$node\", status_class=~\"success\"}[2m])) / sum by(peer) (rate(http_client_get_chunk_duration_seconds_count{instance=\"$node\", status_class=~\"success\"}[2m]))",
@@ -656,7 +767,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_client_get_chunk_duration_seconds_sum{instance=\"$node\", status_class=~\"success\"}[2m])) / sum(rate(http_client_get_chunk_duration_seconds_count{instance=\"$node\", status_class=~\"success\"}[2m]))",
@@ -672,7 +783,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Packing operations performed per second",
       "fieldConfig": {
@@ -718,8 +829,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -730,7 +840,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 23
       },
       "id": 4,
       "options": {
@@ -754,7 +864,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -771,7 +881,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by(packing) (rate(packing_duration_milliseconds_count{instance=\"$node\"}[1h]))",
@@ -785,27 +895,51 @@
       "type": "timeseries"
     }
   ],
-  "preload": false,
   "refresh": "",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "YOUR-NODE-INSTANCE-LABEL",
-          "value": "YOUR-NODE-INSTANCE-LABEL"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
+        "definition": "label_values({job=\"$JOBNAME\"}, instance)",
+        "includeAll": false,
+        "label": "Node",
         "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values({job=\"$JOBNAME\"}, instance)",
+          "refId": "Prometheus-nodename-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "description": "Enter the job_name as specified in prometheus.yml",
+        "hide": 2,
+        "label": "job_name",
+        "name": "JOBNAME",
+        "query": "${VAR_JOBNAME}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOBNAME}",
+          "text": "${VAR_JOBNAME}",
+          "selected": false
+        },
         "options": [
           {
-            "selected": true,
-            "text": "YOUR-NODE-INSTANCE-LABEL",
-            "value": "YOUR-NODE-INSTANCE-LABEL"
+            "value": "${VAR_JOBNAME}",
+            "text": "${VAR_JOBNAME}",
+            "selected": false
           }
-        ],
-        "query": "YOUR-NODE-INSTANCE-LABEL",
-        "type": "textbox"
+        ]
       }
     ]
   },
@@ -815,8 +949,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Sample Syncing/Packing Dashboard",
-  "uid": "cdi53ryl7bvnkf",
-  "version": 36,
+  "title": "Arweave Syncing/Packing",
+  "uid": "arweave-syncpack",
+  "version": 37,
   "weekStart": ""
 }

--- a/mining/metrics.md
+++ b/mining/metrics.md
@@ -18,10 +18,15 @@ You can integrate Prometheus with a number of monitoring and visualization tools
 1. [Setup Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/) to scrape the `/metrics` endpoint of your arweave node.
 2. When you get to the point of defining Prometheus targets to monitor, add an `instance` label for each target that provides a name for your node (can just be your IP if you want). This isn't required in general, but it will make using the sample dashboard easier. e.g.
 ```
-- targets: ['111.222.333.444:1984']
-  labels:
-    instance: 'my-miner'
+  - job_name: arweave
+
+    static_configs:
+      - targets: ['111.222.333.444:1984']
+      labels:
+        instance: 'my-miner'
 ```
+Note:  If you have previously set up your job_name with a value other than the default 'arweave', you will get a chance to override that default during the dashboard import in step 4 below.
+
 3. [Setup Grafana](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/) to visualize the Prometheus data.
 4. [Import the sample dashboard](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/). Sample Dashboard JSON is available [here](grafana.json).
 


### PR DESCRIPTION
For all 3 dashboards:
   A)  Implemented dropdown for node selection, replacing text box
   B)  You can specify the job_name as specified in prometheus.yml during import of the dashboard, which is treated from then on as a constant.
   C)  The default dashboard UID is now in english (e.g. "arweave-syncpack") rather than an incomprehensible hash, and less generic in the case of the debug uid to avoid conflicts.
   D)  Default datasource was changed to local prometheus install rather than grafanacloud-prom, for easier install by miners.
   E)  Minor edits to values like "color "green", hideZeros, barwidth were made automatically by dashboard export process.  Assuming they are a result of updates to schema format implemented by Grafana.  Let me know if you want me to reverse them.
   F)  Standardized title format

1)  Sync Pack Dashboard
    A)  This dashboard had datasource hard coded to "grafanacloud-prom".  Fixed this.
    B)  This dashboard had same uid as the Mining dashboard.  The uid change described above fixes that.
    C)  Restored the "Total Chunks Written" panel at top of this dashboard that was eliminated when dashboard was converted for Replica format.
2)  Mining Dashboard
    A)  Two of the panels, "VDF Step Number" and "Block Height", had two overrides attached that inexplicably hid all the data.  I haven't seen anything in those panels for months.  Given no known reason yet why those overrides are there, I've removed them.  If there was a purpose to those overrrides, happy to put them back, but be aware they make those panels useless for at least one miner.
    B)   This dashboard had same uid as the Syncing/Packing dashboard.  The uid change described above fixes that.
3)  Debug Dashboard - no other changes